### PR TITLE
Require package.json with full name to avoid confusing webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,4 +3,4 @@
  * @ndaidong
 **/
 exports = module.exports = require('./src/main');
-exports.version = require('./package').version;
+exports.version = require('./package.json').version;


### PR DESCRIPTION
Including `bella-scheduler` in webpack throws the following error as it searches for module named `package`

```
ERROR in ~/bella-scheduler/index.js
Module not found: Error: Can't resolve './package' in ' ~/project/node_modules/bella-scheduler'
```